### PR TITLE
Fix: explicit nullable parameter types (PHP 8.4 deprecation)

### DIFF
--- a/schemas/support_agent_expertises.sql
+++ b/schemas/support_agent_expertises.sql
@@ -1,0 +1,19 @@
+-- PostgreSQL
+
+CREATE TABLE support_agent_expertises (
+    id                  bigint NOT NULL DEFAULT nextval('support_agent_expertise_id_seq'::regclass),
+    uuid                uuid DEFAULT gen_random_uuid(),
+    iam_user_id         bigint NOT NULL,
+    common_category_id  bigint NOT NULL,
+    proficiency         smallint NOT NULL DEFAULT 1,
+    is_available        boolean NOT NULL DEFAULT true,
+    iam_account_id      bigint,
+    created_at          timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at          timestamp with time zone,
+    CONSTRAINT support_agent_expertise_common_category_id_fkey FOREIGN KEY (common_category_id) REFERENCES common_categories(id),
+    CONSTRAINT support_agent_expertise_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX support_agent_expertise_lookup_idx ON public.support_agent_expertises USING btree (common_category_id, is_available);
+CREATE UNIQUE INDEX support_agent_expertise_uniq ON public.support_agent_expertises USING btree (iam_user_id, common_category_id) WHERE (deleted_at IS NULL);

--- a/schemas/support_csats.sql
+++ b/schemas/support_csats.sql
@@ -1,0 +1,18 @@
+-- PostgreSQL
+
+CREATE TABLE support_csats (
+    id                 bigint NOT NULL DEFAULT nextval('support_csat_id_seq'::regclass),
+    uuid               uuid DEFAULT gen_random_uuid(),
+    support_ticket_id  bigint NOT NULL,
+    score              smallint NOT NULL,
+    comment            text,
+    iam_account_id     bigint,
+    iam_user_id        bigint,
+    created_at         timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at         timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at         timestamp with time zone,
+    CONSTRAINT support_csat_support_ticket_id_fkey FOREIGN KEY (support_ticket_id) REFERENCES support_tickets(id),
+    CONSTRAINT support_csat_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX support_csat_ticket_idx ON public.support_csats USING btree (support_ticket_id);

--- a/schemas/support_kb_articles.sql
+++ b/schemas/support_kb_articles.sql
@@ -1,0 +1,26 @@
+-- PostgreSQL
+
+CREATE TABLE support_kb_articles (
+    id                  bigint NOT NULL DEFAULT nextval('support_kb_articles_id_seq'::regclass),
+    uuid                uuid DEFAULT gen_random_uuid(),
+    common_category_id  bigint,
+    title               text NOT NULL,
+    slug                text NOT NULL,
+    body                text NOT NULL,
+    excerpt             text,
+    is_published        boolean NOT NULL DEFAULT false,
+    view_count          integer NOT NULL DEFAULT 0,
+    helpful_count       integer NOT NULL DEFAULT 0,
+    not_helpful_count   integer NOT NULL DEFAULT 0,
+    iam_account_id      bigint,
+    iam_user_id         bigint,
+    created_at          timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at          timestamp with time zone,
+    CONSTRAINT support_kb_articles_common_category_id_fkey FOREIGN KEY (common_category_id) REFERENCES common_categories(id),
+    CONSTRAINT support_kb_articles_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX support_kb_articles_category_idx ON public.support_kb_articles USING btree (common_category_id);
+CREATE INDEX support_kb_articles_fts_idx ON public.support_kb_articles USING gin (to_tsvector('simple'::regconfig, ((COALESCE(title, ''::text) || ' '::text) || COALESCE(body, ''::text))));
+CREATE INDEX support_kb_articles_slug_idx ON public.support_kb_articles USING btree (slug);

--- a/schemas/support_kb_articles_perspective.sql
+++ b/schemas/support_kb_articles_perspective.sql
@@ -1,0 +1,26 @@
+-- PostgreSQL
+-- VIEW (read-only; re-run this file with CREATE OR REPLACE VIEW whenever the SELECT needs to change)
+
+CREATE OR REPLACE VIEW support_kb_articles_perspective AS
+SELECT k.id,
+    k.uuid,
+    k.common_category_id,
+    k.title,
+    k.slug,
+    k.body,
+    k.excerpt,
+    k.is_published,
+    k.view_count,
+    k.helpful_count,
+    k.not_helpful_count,
+    k.iam_account_id,
+    k.iam_user_id,
+    cc.name AS category_name,
+    u.fullname AS author_name,
+    k.created_at,
+    k.updated_at,
+    k.deleted_at
+   FROM support_kb_articles k
+     LEFT JOIN common_categories cc ON cc.id = k.common_category_id
+     LEFT JOIN iam_users u ON u.id = k.iam_user_id
+  WHERE k.deleted_at IS NULL;

--- a/schemas/support_sla_policies.sql
+++ b/schemas/support_sla_policies.sql
@@ -1,0 +1,17 @@
+-- PostgreSQL
+
+CREATE TABLE support_sla_policies (
+    id                         bigint NOT NULL DEFAULT nextval('support_sla_policies_id_seq'::regclass),
+    uuid                       uuid DEFAULT gen_random_uuid(),
+    name                       text NOT NULL,
+    priority                   smallint NOT NULL,
+    response_target_minutes    integer NOT NULL,
+    resolution_target_minutes  integer NOT NULL,
+    is_active                  boolean NOT NULL DEFAULT true,
+    iam_account_id             bigint,
+    iam_user_id                bigint,
+    created_at                 timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at                 timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at                 timestamp with time zone,
+    CONSTRAINT support_sla_policies_pkey PRIMARY KEY (id)
+);

--- a/schemas/support_tests.sql
+++ b/schemas/support_tests.sql
@@ -1,0 +1,16 @@
+-- PostgreSQL
+
+CREATE TABLE support_tests (
+    id                 bigint NOT NULL DEFAULT nextval('support_tests_id_seq'::regclass),
+    uuid               uuid DEFAULT gen_random_uuid(),
+    name               text NOT NULL,
+    result             text NOT NULL, -- [ui:markdown]
+    data               json NOT NULL,
+    is_passed          boolean DEFAULT true,
+    support_ticket_id  bigint NOT NULL,
+    common_action_id   bigint NOT NULL,
+    created_at         timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at         timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at         timestamp with time zone,
+    CONSTRAINT support_tests_pkey PRIMARY KEY (id)
+);

--- a/schemas/support_ticket_audits.sql
+++ b/schemas/support_ticket_audits.sql
@@ -1,0 +1,13 @@
+-- PostgreSQL
+
+CREATE TABLE support_ticket_audits (
+    id           bigint NOT NULL DEFAULT nextval('support_ticket_audits_id_seq'::regclass),
+    uuid         uuid DEFAULT gen_random_uuid(),
+    comments     text, -- [ui:markdown]
+    iam_user_id  bigint,
+    point        smallint DEFAULT 0,
+    created_at   timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at   timestamp with time zone,
+    CONSTRAINT support_ticket_audits_pkey PRIMARY KEY (id)
+);

--- a/schemas/support_ticket_comments.sql
+++ b/schemas/support_ticket_comments.sql
@@ -1,0 +1,16 @@
+-- PostgreSQL
+
+CREATE TABLE support_ticket_comments (
+    id                 bigint NOT NULL DEFAULT nextval('support_comments_id_seq'::regclass),
+    uuid               uuid DEFAULT gen_random_uuid(),
+    comment            text NOT NULL, -- [ui:markdown]
+    iam_account_id     bigint,
+    iam_user_id        bigint,
+    support_ticket_id  bigint NOT NULL,
+    created_at         timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at         timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at         timestamp with time zone,
+    is_system_message  boolean DEFAULT false,
+    is_internal        boolean NOT NULL DEFAULT false,
+    CONSTRAINT support_ticket_comments_pkey PRIMARY KEY (id)
+);

--- a/schemas/support_ticket_comments_perspective.sql
+++ b/schemas/support_ticket_comments_perspective.sql
@@ -1,0 +1,22 @@
+-- PostgreSQL
+-- VIEW (read-only; re-run this file with CREATE OR REPLACE VIEW whenever the SELECT needs to change)
+
+CREATE OR REPLACE VIEW support_ticket_comments_perspective AS
+SELECT stc.id,
+    stc.uuid,
+    stc.comment,
+    stc.iam_account_id,
+    stc.iam_user_id,
+    iu.fullname,
+    iu.email,
+    iu.phone_number,
+    iu.pronoun,
+    ia.name,
+    ia.iam_account_type_id,
+    stc.support_ticket_id,
+    stc.created_at,
+    stc.updated_at,
+    stc.deleted_at
+   FROM support_ticket_comments stc
+     JOIN iam_users iu ON stc.iam_user_id = iu.id
+     JOIN iam_accounts ia ON ia.id = stc.iam_account_id;

--- a/schemas/support_tickets.sql
+++ b/schemas/support_tickets.sql
@@ -1,0 +1,43 @@
+-- PostgreSQL
+
+CREATE TABLE support_tickets (
+    id                           bigint NOT NULL DEFAULT nextval('support_tickets_id_seq'::regclass),
+    uuid                         uuid DEFAULT gen_random_uuid(),
+    title                        text NOT NULL,
+    description                  text, -- [ui:markdown]
+    iam_account_id               bigint,
+    iam_user_id                  bigint,
+    tags                         text[] NOT NULL DEFAULT '{}'::text[],
+    is_closed                    boolean DEFAULT false, -- [ro]
+    level                        smallint DEFAULT 1, -- [ro]
+    priority                     smallint DEFAULT 1, -- [ro]
+    response_time                timestamp with time zone, -- [ro]
+    object_id                    bigint, -- [ro]
+    object_type                  text, -- [ro]
+    created_at                   timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at                   timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at                   timestamp with time zone,
+    is_public                    boolean DEFAULT false,
+    responsible_user_id          bigint, -- [alias:iam_user_id]
+    time_spent                   integer, -- time spent in terms of minutes
+    watcher_user_ids             bigint[],
+    watcher_account_ids          bigint[],
+    support_seeker_account_id    bigint, -- [alias:iam_account_id]
+    status                       text NOT NULL DEFAULT 'open'::text,
+    common_category_id           bigint,
+    first_response_at            timestamp with time zone,
+    resolved_at                  timestamp with time zone,
+    reopened_count               integer NOT NULL DEFAULT 0,
+    is_first_contact_resolution  boolean NOT NULL DEFAULT false,
+    sla_resolution_due_at        timestamp with time zone,
+    sla_response_breached        boolean NOT NULL DEFAULT false,
+    sla_resolution_breached      boolean NOT NULL DEFAULT false,
+    CONSTRAINT support_tickets_status_chk CHECK ((status = ANY (ARRAY['open'::text, 'pending'::text, 'waiting_on_customer'::text, 'resolved'::text, 'closed'::text]))),
+    CONSTRAINT support_tickets_common_category_id_fk FOREIGN KEY (common_category_id) REFERENCES common_categories(id),
+    CONSTRAINT support_tickets_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX support_tickets_common_category_idx ON public.support_tickets USING btree (common_category_id);
+CREATE INDEX support_tickets_responsible_user_idx ON public.support_tickets USING btree (responsible_user_id);
+CREATE INDEX support_tickets_sla_due_open_idx ON public.support_tickets USING btree (sla_resolution_due_at) WHERE ((deleted_at IS NULL) AND (status <> ALL (ARRAY['resolved'::text, 'closed'::text])));
+CREATE INDEX support_tickets_status_idx ON public.support_tickets USING btree (status);

--- a/schemas/support_tickets_perspective.sql
+++ b/schemas/support_tickets_perspective.sql
@@ -1,0 +1,57 @@
+-- PostgreSQL
+-- VIEW (read-only; re-run this file with CREATE OR REPLACE VIEW whenever the SELECT needs to change)
+
+CREATE OR REPLACE VIEW support_tickets_perspective AS
+SELECT t.id,
+    t.uuid,
+    t.title,
+    t.description,
+    t.iam_account_id,
+    t.iam_user_id,
+    t.tags,
+    t.is_closed,
+    t.is_public,
+    t.level,
+    t.priority,
+    t.status,
+    t.common_category_id,
+    t.response_time,
+    t.first_response_at,
+    t.resolved_at,
+    t.sla_resolution_due_at,
+    t.sla_response_breached,
+    t.sla_resolution_breached,
+    t.reopened_count,
+    t.is_first_contact_resolution,
+    t.object_id,
+    t.object_type,
+    t.responsible_user_id,
+    t.time_spent,
+    t.watcher_user_ids,
+    t.watcher_account_ids,
+    t.support_seeker_account_id,
+    u.fullname,
+    u.email,
+    u.phone_number,
+    u.pronoun,
+    a.name,
+    a.iam_account_type_id,
+    sa.name AS support_seeker_name,
+    ru.fullname AS responsible_name,
+    cc.name AS category_name,
+    cs.score AS csat_score,
+    t.created_at,
+    t.updated_at,
+    t.deleted_at
+   FROM support_tickets t
+     LEFT JOIN iam_users u ON u.id = t.iam_user_id
+     LEFT JOIN iam_accounts a ON a.id = t.iam_account_id
+     LEFT JOIN iam_accounts sa ON sa.id = t.support_seeker_account_id
+     LEFT JOIN iam_users ru ON ru.id = t.responsible_user_id
+     LEFT JOIN common_categories cc ON cc.id = t.common_category_id
+     LEFT JOIN LATERAL ( SELECT c.score
+           FROM support_csats c
+          WHERE c.support_ticket_id = t.id AND c.deleted_at IS NULL
+          ORDER BY c.created_at DESC
+         LIMIT 1) cs ON true
+  WHERE t.deleted_at IS NULL;

--- a/src/Database/Filters/AgentExpertisesQueryFilter.php
+++ b/src/Database/Filters/AgentExpertisesQueryFilter.php
@@ -31,7 +31,7 @@ class AgentExpertisesQueryFilter extends AbstractQueryFilter
         return $this->builder->where('proficiency', $operator, $value);
     }
 
-    
+
     public function isAvailable($value)
     {
         return $this->builder->where('is_available', $value);
@@ -42,7 +42,7 @@ class AgentExpertisesQueryFilter extends AbstractQueryFilter
     {
         return $this->isAvailable($value);
     }
-     
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -118,7 +118,7 @@ class AgentExpertisesQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function commonCategoryId($value)
     {
             $commonCategory = \NextDeveloper\Commons\Database\Models\Categories::where('uuid', $value)->first();
@@ -133,7 +133,7 @@ class AgentExpertisesQueryFilter extends AbstractQueryFilter
     {
         return $this->commonCategory($value);
     }
-    
+
     public function iamAccountId($value)
     {
             $iamAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -143,6 +143,6 @@ class AgentExpertisesQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 }

--- a/src/Database/Filters/CsatsQueryFilter.php
+++ b/src/Database/Filters/CsatsQueryFilter.php
@@ -17,13 +17,13 @@ class CsatsQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function comment($value)
     {
         return $this->builder->where('comment', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function score($value)
     {
         $operator = substr($value, 0, 1);
@@ -37,7 +37,7 @@ class CsatsQueryFilter extends AbstractQueryFilter
         return $this->builder->where('score', $operator, $value);
     }
 
-    
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -118,7 +118,7 @@ class CsatsQueryFilter extends AbstractQueryFilter
     {
         return $this->supportTicket($value);
     }
-    
+
     public function iamAccountId($value)
     {
             $iamAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -128,7 +128,7 @@ class CsatsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -138,6 +138,6 @@ class CsatsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 }

--- a/src/Database/Filters/KbArticlesPerspectiveQueryFilter.php
+++ b/src/Database/Filters/KbArticlesPerspectiveQueryFilter.php
@@ -20,31 +20,31 @@ class KbArticlesPerspectiveQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function title($value)
     {
         return $this->builder->where('title', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function slug($value)
     {
         return $this->builder->where('slug', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function body($value)
     {
         return $this->builder->where('body', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function excerpt($value)
     {
         return $this->builder->where('excerpt', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function categoryName($value)
     {
         return $this->builder->where('category_name', 'ilike', '%' . $value . '%');
@@ -55,7 +55,7 @@ class KbArticlesPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->categoryName($value);
     }
-        
+
     public function authorName($value)
     {
         return $this->builder->where('author_name', 'ilike', '%' . $value . '%');
@@ -66,7 +66,7 @@ class KbArticlesPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->authorName($value);
     }
-    
+
     public function viewCount($value)
     {
         $operator = substr($value, 0, 1);
@@ -85,7 +85,7 @@ class KbArticlesPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->viewCount($value);
     }
-    
+
     public function helpfulCount($value)
     {
         $operator = substr($value, 0, 1);
@@ -104,7 +104,7 @@ class KbArticlesPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->helpfulCount($value);
     }
-    
+
     public function notHelpfulCount($value)
     {
         $operator = substr($value, 0, 1);
@@ -123,7 +123,7 @@ class KbArticlesPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->notHelpfulCount($value);
     }
-    
+
     public function isPublished($value)
     {
         return $this->builder->where('is_published', $value);
@@ -134,7 +134,7 @@ class KbArticlesPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isPublished($value);
     }
-     
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -215,7 +215,7 @@ class KbArticlesPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->commonCategory($value);
     }
-    
+
     public function iamAccountId($value)
     {
             $iamAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -225,7 +225,7 @@ class KbArticlesPerspectiveQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -235,6 +235,6 @@ class KbArticlesPerspectiveQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 }

--- a/src/Database/Filters/KbArticlesQueryFilter.php
+++ b/src/Database/Filters/KbArticlesQueryFilter.php
@@ -20,31 +20,31 @@ class KbArticlesQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function title($value)
     {
         return $this->builder->where('title', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function slug($value)
     {
         return $this->builder->where('slug', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function body($value)
     {
         return $this->builder->where('body', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function excerpt($value)
     {
         return $this->builder->where('excerpt', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function viewCount($value)
     {
         $operator = substr($value, 0, 1);
@@ -63,7 +63,7 @@ class KbArticlesQueryFilter extends AbstractQueryFilter
     {
         return $this->viewCount($value);
     }
-    
+
     public function helpfulCount($value)
     {
         $operator = substr($value, 0, 1);
@@ -82,7 +82,7 @@ class KbArticlesQueryFilter extends AbstractQueryFilter
     {
         return $this->helpfulCount($value);
     }
-    
+
     public function notHelpfulCount($value)
     {
         $operator = substr($value, 0, 1);
@@ -101,7 +101,7 @@ class KbArticlesQueryFilter extends AbstractQueryFilter
     {
         return $this->notHelpfulCount($value);
     }
-    
+
     public function isPublished($value)
     {
         return $this->builder->where('is_published', $value);
@@ -112,7 +112,7 @@ class KbArticlesQueryFilter extends AbstractQueryFilter
     {
         return $this->isPublished($value);
     }
-     
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -193,7 +193,7 @@ class KbArticlesQueryFilter extends AbstractQueryFilter
     {
         return $this->commonCategory($value);
     }
-    
+
     public function iamAccountId($value)
     {
             $iamAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -203,7 +203,7 @@ class KbArticlesQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -213,6 +213,6 @@ class KbArticlesQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 }

--- a/src/Database/Filters/SlaPoliciesQueryFilter.php
+++ b/src/Database/Filters/SlaPoliciesQueryFilter.php
@@ -17,13 +17,13 @@ class SlaPoliciesQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function name($value)
     {
         return $this->builder->where('name', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function priority($value)
     {
         $operator = substr($value, 0, 1);
@@ -37,7 +37,7 @@ class SlaPoliciesQueryFilter extends AbstractQueryFilter
         return $this->builder->where('priority', $operator, $value);
     }
 
-    
+
     public function responseTargetMinutes($value)
     {
         $operator = substr($value, 0, 1);
@@ -56,7 +56,7 @@ class SlaPoliciesQueryFilter extends AbstractQueryFilter
     {
         return $this->responseTargetMinutes($value);
     }
-    
+
     public function resolutionTargetMinutes($value)
     {
         $operator = substr($value, 0, 1);
@@ -75,7 +75,7 @@ class SlaPoliciesQueryFilter extends AbstractQueryFilter
     {
         return $this->resolutionTargetMinutes($value);
     }
-    
+
     public function isActive($value)
     {
         return $this->builder->where('is_active', $value);
@@ -86,7 +86,7 @@ class SlaPoliciesQueryFilter extends AbstractQueryFilter
     {
         return $this->isActive($value);
     }
-     
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -162,7 +162,7 @@ class SlaPoliciesQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -172,6 +172,6 @@ class SlaPoliciesQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 }

--- a/src/Database/Filters/TestsQueryFilter.php
+++ b/src/Database/Filters/TestsQueryFilter.php
@@ -17,19 +17,19 @@ class TestsQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function name($value)
     {
         return $this->builder->where('name', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function result($value)
     {
         return $this->builder->where('result', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function isPassed($value)
     {
         return $this->builder->where('is_passed', $value);
@@ -40,7 +40,7 @@ class TestsQueryFilter extends AbstractQueryFilter
     {
         return $this->isPassed($value);
     }
-     
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -121,7 +121,7 @@ class TestsQueryFilter extends AbstractQueryFilter
     {
         return $this->supportTicket($value);
     }
-    
+
     public function commonActionId($value)
     {
             $commonAction = \NextDeveloper\Commons\Database\Models\Actions::where('uuid', $value)->first();
@@ -136,6 +136,6 @@ class TestsQueryFilter extends AbstractQueryFilter
     {
         return $this->commonAction($value);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 }

--- a/src/Database/Filters/TicketAuditsQueryFilter.php
+++ b/src/Database/Filters/TicketAuditsQueryFilter.php
@@ -17,13 +17,13 @@ class TicketAuditsQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function comments($value)
     {
         return $this->builder->where('comments', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function point($value)
     {
         $operator = substr($value, 0, 1);
@@ -37,7 +37,7 @@ class TicketAuditsQueryFilter extends AbstractQueryFilter
         return $this->builder->where('point', $operator, $value);
     }
 
-    
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -113,6 +113,6 @@ class TicketAuditsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 }

--- a/src/Database/Filters/TicketCommentsPerspectiveQueryFilter.php
+++ b/src/Database/Filters/TicketCommentsPerspectiveQueryFilter.php
@@ -17,25 +17,25 @@ class TicketCommentsPerspectiveQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function comment($value)
     {
         return $this->builder->where('comment', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function fullname($value)
     {
         return $this->builder->where('fullname', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function email($value)
     {
         return $this->builder->where('email', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function phoneNumber($value)
     {
         return $this->builder->where('phone_number', 'ilike', '%' . $value . '%');
@@ -46,19 +46,19 @@ class TicketCommentsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->phoneNumber($value);
     }
-        
+
     public function pronoun($value)
     {
         return $this->builder->where('pronoun', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function name($value)
     {
         return $this->builder->where('name', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -134,7 +134,7 @@ class TicketCommentsPerspectiveQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -144,7 +144,7 @@ class TicketCommentsPerspectiveQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamAccountTypeId($value)
     {
             $iamAccountType = \NextDeveloper\IAM\Database\Models\AccountTypes::where('uuid', $value)->first();
@@ -159,7 +159,7 @@ class TicketCommentsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->iamAccountType($value);
     }
-    
+
     public function supportTicketId($value)
     {
             $supportTicket = \NextDeveloper\Support\Database\Models\Tickets::where('uuid', $value)->first();
@@ -174,6 +174,6 @@ class TicketCommentsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->supportTicket($value);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 }

--- a/src/Database/Filters/TicketCommentsQueryFilter.php
+++ b/src/Database/Filters/TicketCommentsQueryFilter.php
@@ -17,13 +17,13 @@ class TicketCommentsQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function comment($value)
     {
         return $this->builder->where('comment', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function isSystemMessage($value)
     {
         return $this->builder->where('is_system_message', $value);
@@ -34,7 +34,7 @@ class TicketCommentsQueryFilter extends AbstractQueryFilter
     {
         return $this->isSystemMessage($value);
     }
-     
+
     public function isInternal($value)
     {
         return $this->builder->where('is_internal', $value);
@@ -45,7 +45,7 @@ class TicketCommentsQueryFilter extends AbstractQueryFilter
     {
         return $this->isInternal($value);
     }
-     
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -121,7 +121,7 @@ class TicketCommentsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -131,7 +131,7 @@ class TicketCommentsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function supportTicketId($value)
     {
             $supportTicket = \NextDeveloper\Support\Database\Models\Tickets::where('uuid', $value)->first();
@@ -146,6 +146,6 @@ class TicketCommentsQueryFilter extends AbstractQueryFilter
     {
         return $this->supportTicket($value);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 }

--- a/src/Database/Filters/TicketsPerspectiveQueryFilter.php
+++ b/src/Database/Filters/TicketsPerspectiveQueryFilter.php
@@ -41,25 +41,25 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function title($value)
     {
         return $this->builder->where('title', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function description($value)
     {
         return $this->builder->where('description', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function status($value)
     {
         return $this->builder->where('status', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function objectType($value)
     {
         return $this->builder->where('object_type', 'ilike', '%' . $value . '%');
@@ -70,19 +70,19 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->objectType($value);
     }
-        
+
     public function fullname($value)
     {
         return $this->builder->where('fullname', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function email($value)
     {
         return $this->builder->where('email', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function phoneNumber($value)
     {
         return $this->builder->where('phone_number', 'ilike', '%' . $value . '%');
@@ -93,19 +93,19 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->phoneNumber($value);
     }
-        
+
     public function pronoun($value)
     {
         return $this->builder->where('pronoun', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function name($value)
     {
         return $this->builder->where('name', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function supportSeekerName($value)
     {
         return $this->builder->where('support_seeker_name', 'ilike', '%' . $value . '%');
@@ -116,7 +116,7 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->supportSeekerName($value);
     }
-        
+
     public function responsibleName($value)
     {
         return $this->builder->where('responsible_name', 'ilike', '%' . $value . '%');
@@ -127,7 +127,7 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->responsibleName($value);
     }
-        
+
     public function categoryName($value)
     {
         return $this->builder->where('category_name', 'ilike', '%' . $value . '%');
@@ -138,7 +138,7 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->categoryName($value);
     }
-    
+
     public function level($value)
     {
         $operator = substr($value, 0, 1);
@@ -152,7 +152,7 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
         return $this->builder->where('level', $operator, $value);
     }
 
-    
+
     public function priority($value)
     {
         $operator = substr($value, 0, 1);
@@ -166,7 +166,7 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
         return $this->builder->where('priority', $operator, $value);
     }
 
-    
+
     public function reopenedCount($value)
     {
         $operator = substr($value, 0, 1);
@@ -185,7 +185,7 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->reopenedCount($value);
     }
-    
+
     public function timeSpent($value)
     {
         $operator = substr($value, 0, 1);
@@ -204,7 +204,7 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->timeSpent($value);
     }
-    
+
     public function csatScore($value)
     {
         $operator = substr($value, 0, 1);
@@ -223,7 +223,7 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->csatScore($value);
     }
-    
+
     public function isClosed($value)
     {
         return $this->builder->where('is_closed', $value);
@@ -234,7 +234,7 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isClosed($value);
     }
-     
+
     public function isPublic($value)
     {
         return $this->builder->where('is_public', $value);
@@ -245,7 +245,7 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isPublic($value);
     }
-     
+
     public function isFirstContactResolution($value)
     {
         return $this->builder->where('is_first_contact_resolution', $value);
@@ -256,7 +256,7 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isFirstContactResolution($value);
     }
-     
+
     public function responseTimeStart($date)
     {
         return $this->builder->where('response_time', '>=', $date);
@@ -420,7 +420,7 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -430,7 +430,7 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function commonCategoryId($value)
     {
             $commonCategory = \NextDeveloper\Commons\Database\Models\Categories::where('uuid', $value)->first();
@@ -445,7 +445,7 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->commonCategory($value);
     }
-    
+
     public function responsibleUserId($value)
     {
             $responsibleUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -460,7 +460,7 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->responsibleUser($value);
     }
-    
+
     public function supportSeekerAccountId($value)
     {
             $supportSeekerAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -475,7 +475,7 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->supportSeekerAccount($value);
     }
-    
+
     public function iamAccountTypeId($value)
     {
             $iamAccountType = \NextDeveloper\IAM\Database\Models\AccountTypes::where('uuid', $value)->first();
@@ -490,6 +490,6 @@ class TicketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->iamAccountType($value);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 }

--- a/src/Database/Filters/TicketsQueryFilter.php
+++ b/src/Database/Filters/TicketsQueryFilter.php
@@ -40,19 +40,19 @@ class TicketsQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function title($value)
     {
         return $this->builder->where('title', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function description($value)
     {
         return $this->builder->where('description', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function objectType($value)
     {
         return $this->builder->where('object_type', 'ilike', '%' . $value . '%');
@@ -63,13 +63,13 @@ class TicketsQueryFilter extends AbstractQueryFilter
     {
         return $this->objectType($value);
     }
-        
+
     public function status($value)
     {
         return $this->builder->where('status', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function level($value)
     {
         $operator = substr($value, 0, 1);
@@ -83,7 +83,7 @@ class TicketsQueryFilter extends AbstractQueryFilter
         return $this->builder->where('level', $operator, $value);
     }
 
-    
+
     public function priority($value)
     {
         $operator = substr($value, 0, 1);
@@ -97,7 +97,7 @@ class TicketsQueryFilter extends AbstractQueryFilter
         return $this->builder->where('priority', $operator, $value);
     }
 
-    
+
     public function timeSpent($value)
     {
         $operator = substr($value, 0, 1);
@@ -116,7 +116,7 @@ class TicketsQueryFilter extends AbstractQueryFilter
     {
         return $this->timeSpent($value);
     }
-    
+
     public function reopenedCount($value)
     {
         $operator = substr($value, 0, 1);
@@ -135,7 +135,7 @@ class TicketsQueryFilter extends AbstractQueryFilter
     {
         return $this->reopenedCount($value);
     }
-    
+
     public function isClosed($value)
     {
         return $this->builder->where('is_closed', $value);
@@ -146,7 +146,7 @@ class TicketsQueryFilter extends AbstractQueryFilter
     {
         return $this->isClosed($value);
     }
-     
+
     public function isPublic($value)
     {
         return $this->builder->where('is_public', $value);
@@ -157,7 +157,7 @@ class TicketsQueryFilter extends AbstractQueryFilter
     {
         return $this->isPublic($value);
     }
-     
+
     public function isFirstContactResolution($value)
     {
         return $this->builder->where('is_first_contact_resolution', $value);
@@ -168,7 +168,7 @@ class TicketsQueryFilter extends AbstractQueryFilter
     {
         return $this->isFirstContactResolution($value);
     }
-     
+
     public function responseTimeStart($date)
     {
         return $this->builder->where('response_time', '>=', $date);
@@ -332,7 +332,7 @@ class TicketsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -342,7 +342,7 @@ class TicketsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function responsibleUserId($value)
     {
             $responsibleUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -357,7 +357,7 @@ class TicketsQueryFilter extends AbstractQueryFilter
     {
         return $this->responsibleUser($value);
     }
-    
+
     public function supportSeekerAccountId($value)
     {
             $supportSeekerAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -372,7 +372,7 @@ class TicketsQueryFilter extends AbstractQueryFilter
     {
         return $this->supportSeekerAccount($value);
     }
-    
+
     public function commonCategoryId($value)
     {
             $commonCategory = \NextDeveloper\Commons\Database\Models\Categories::where('uuid', $value)->first();
@@ -387,6 +387,6 @@ class TicketsQueryFilter extends AbstractQueryFilter
     {
         return $this->commonCategory($value);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 }

--- a/src/Database/Models/AgentExpertises.php
+++ b/src/Database/Models/AgentExpertises.php
@@ -143,6 +143,6 @@ class AgentExpertises extends Model
     {
         return $this->belongsTo(\NextDeveloper\Commons\Database\Models\Categories::class);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 }

--- a/src/Database/Models/Csats.php
+++ b/src/Database/Models/Csats.php
@@ -143,6 +143,6 @@ class Csats extends Model
     {
         return $this->belongsTo(\NextDeveloper\Support\Database\Models\Tickets::class);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 }

--- a/src/Database/Models/KbArticles.php
+++ b/src/Database/Models/KbArticles.php
@@ -161,6 +161,6 @@ class KbArticles extends Model
     {
         return $this->belongsTo(\NextDeveloper\Commons\Database\Models\Categories::class);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 }

--- a/src/Database/Models/Tests.php
+++ b/src/Database/Models/Tests.php
@@ -148,11 +148,11 @@ class Tests extends Model
     {
         return $this->belongsTo(\NextDeveloper\Commons\Database\Models\Actions::class);
     }
-    
+
     public function tickets() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\Support\Database\Models\Tickets::class);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 }

--- a/src/Database/Models/TicketAudits.php
+++ b/src/Database/Models/TicketAudits.php
@@ -138,6 +138,6 @@ class TicketAudits extends Model
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Users::class);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 }

--- a/src/Database/Models/TicketComments.php
+++ b/src/Database/Models/TicketComments.php
@@ -146,11 +146,11 @@ class TicketComments extends Model
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Accounts::class);
     }
-    
+
     public function users() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Users::class);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 }

--- a/src/Database/Models/Tickets.php
+++ b/src/Database/Models/Tickets.php
@@ -210,17 +210,17 @@ class Tickets extends Model
     {
         return $this->belongsTo(\NextDeveloper\Commons\Database\Models\Categories::class);
     }
-    
+
     public function accounts() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Accounts::class);
     }
-    
+
     public function users() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Users::class);
     }
-    
+
     public function csats() : \Illuminate\Database\Eloquent\Relations\HasMany
     {
         return $this->hasMany(\NextDeveloper\Support\Database\Models\Csats::class);

--- a/src/Http/Transformers/AbstractTransformers/AbstractAgentExpertisesTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractAgentExpertisesTransformer.php
@@ -57,7 +57,7 @@ class AbstractAgentExpertisesTransformer extends AbstractTransformer
                                                 $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
                                                             $commonCategoryId = \NextDeveloper\Commons\Database\Models\Categories::where('id', $model->common_category_id)->first();
                                                             $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractCsatsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractCsatsTransformer.php
@@ -57,7 +57,7 @@ class AbstractCsatsTransformer extends AbstractTransformer
                                                 $supportTicketId = \NextDeveloper\Support\Database\Models\Tickets::where('id', $model->support_ticket_id)->first();
                                                             $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractKbArticlesPerspectiveTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractKbArticlesPerspectiveTransformer.php
@@ -57,7 +57,7 @@ class AbstractKbArticlesPerspectiveTransformer extends AbstractTransformer
                                                 $commonCategoryId = \NextDeveloper\Commons\Database\Models\Categories::where('id', $model->common_category_id)->first();
                                                             $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractKbArticlesTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractKbArticlesTransformer.php
@@ -57,7 +57,7 @@ class AbstractKbArticlesTransformer extends AbstractTransformer
                                                 $commonCategoryId = \NextDeveloper\Commons\Database\Models\Categories::where('id', $model->common_category_id)->first();
                                                             $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractSlaPoliciesTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractSlaPoliciesTransformer.php
@@ -56,7 +56,7 @@ class AbstractSlaPoliciesTransformer extends AbstractTransformer
     {
                                                 $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractTestsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractTestsTransformer.php
@@ -56,7 +56,7 @@ class AbstractTestsTransformer extends AbstractTransformer
     {
                                                 $supportTicketId = \NextDeveloper\Support\Database\Models\Tickets::where('id', $model->support_ticket_id)->first();
                                                             $commonActionId = \NextDeveloper\Commons\Database\Models\Actions::where('id', $model->common_action_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractTicketAuditsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractTicketAuditsTransformer.php
@@ -55,7 +55,7 @@ class AbstractTicketAuditsTransformer extends AbstractTransformer
     public function transform(TicketAudits $model)
     {
                                                 $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractTicketCommentsPerspectiveTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractTicketCommentsPerspectiveTransformer.php
@@ -58,7 +58,7 @@ class AbstractTicketCommentsPerspectiveTransformer extends AbstractTransformer
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
                                                             $iamAccountTypeId = \NextDeveloper\IAM\Database\Models\AccountTypes::where('id', $model->iam_account_type_id)->first();
                                                             $supportTicketId = \NextDeveloper\Support\Database\Models\Tickets::where('id', $model->support_ticket_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractTicketCommentsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractTicketCommentsTransformer.php
@@ -57,7 +57,7 @@ class AbstractTicketCommentsTransformer extends AbstractTransformer
                                                 $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
                                                             $supportTicketId = \NextDeveloper\Support\Database\Models\Tickets::where('id', $model->support_ticket_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractTicketsPerspectiveTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractTicketsPerspectiveTransformer.php
@@ -64,7 +64,7 @@ class AbstractTicketsPerspectiveTransformer extends AbstractTransformer
                                                             $responsibleUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->responsible_user_id)->first();
                                                             $supportSeekerAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->support_seeker_account_id)->first();
                                                             $iamAccountTypeId = \NextDeveloper\IAM\Database\Models\AccountTypes::where('id', $model->iam_account_type_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractTicketsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractTicketsTransformer.php
@@ -62,7 +62,7 @@ class AbstractTicketsTransformer extends AbstractTransformer
                                                             $responsibleUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->responsible_user_id)->first();
                                                             $supportSeekerAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->support_seeker_account_id)->first();
                                                             $commonCategoryId = \NextDeveloper\Commons\Database\Models\Categories::where('id', $model->common_category_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Services/AbstractServices/AbstractAgentExpertisesService.php
+++ b/src/Services/AbstractServices/AbstractAgentExpertisesService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractAgentExpertisesService
 {
-    public static function get(AgentExpertisesQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?AgentExpertisesQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 
@@ -190,7 +190,7 @@ class AbstractAgentExpertisesService
                 $data['iam_user_id']
             );
         }
-                    
+
         if(!array_key_exists('iam_user_id', $data)) {
             $data['iam_user_id']    = UserHelper::me()->id;
         }
@@ -206,11 +206,11 @@ class AbstractAgentExpertisesService
                 $data['iam_account_id']
             );
         }
-            
+
         if(!array_key_exists('iam_account_id', $data)) {
             $data['iam_account_id'] = UserHelper::currentAccount()->id;
         }
-                        
+
         try {
             $model = AgentExpertises::create($data);
         } catch(\Exception $e) {
@@ -274,7 +274,7 @@ class AbstractAgentExpertisesService
                 $data['iam_account_id']
             );
         }
-    
+
         try {
             $isUpdated = $model->update($data);
             $model = $model->fresh();

--- a/src/Services/AbstractServices/AbstractCsatsService.php
+++ b/src/Services/AbstractServices/AbstractCsatsService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractCsatsService
 {
-    public static function get(CsatsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?CsatsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 
@@ -196,7 +196,7 @@ class AbstractCsatsService
                 $data['iam_account_id']
             );
         }
-            
+
         if(!array_key_exists('iam_account_id', $data)) {
             $data['iam_account_id'] = UserHelper::currentAccount()->id;
         }
@@ -206,11 +206,11 @@ class AbstractCsatsService
                 $data['iam_user_id']
             );
         }
-                    
+
         if(!array_key_exists('iam_user_id', $data)) {
             $data['iam_user_id']    = UserHelper::me()->id;
         }
-            
+
         try {
             $model = Csats::create($data);
         } catch(\Exception $e) {
@@ -274,7 +274,7 @@ class AbstractCsatsService
                 $data['iam_user_id']
             );
         }
-    
+
         try {
             $isUpdated = $model->update($data);
             $model = $model->fresh();

--- a/src/Services/AbstractServices/AbstractKbArticlesPerspectiveService.php
+++ b/src/Services/AbstractServices/AbstractKbArticlesPerspectiveService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractKbArticlesPerspectiveService
 {
-    public static function get(KbArticlesPerspectiveQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?KbArticlesPerspectiveQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 
@@ -196,7 +196,7 @@ class AbstractKbArticlesPerspectiveService
                 $data['iam_account_id']
             );
         }
-            
+
         if(!array_key_exists('iam_account_id', $data)) {
             $data['iam_account_id'] = UserHelper::currentAccount()->id;
         }
@@ -206,11 +206,11 @@ class AbstractKbArticlesPerspectiveService
                 $data['iam_user_id']
             );
         }
-                    
+
         if(!array_key_exists('iam_user_id', $data)) {
             $data['iam_user_id']    = UserHelper::me()->id;
         }
-            
+
         try {
             $model = KbArticlesPerspective::create($data);
         } catch(\Exception $e) {
@@ -274,7 +274,7 @@ class AbstractKbArticlesPerspectiveService
                 $data['iam_user_id']
             );
         }
-    
+
         try {
             $isUpdated = $model->update($data);
             $model = $model->fresh();

--- a/src/Services/AbstractServices/AbstractKbArticlesService.php
+++ b/src/Services/AbstractServices/AbstractKbArticlesService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractKbArticlesService
 {
-    public static function get(KbArticlesQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?KbArticlesQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 
@@ -196,7 +196,7 @@ class AbstractKbArticlesService
                 $data['iam_account_id']
             );
         }
-            
+
         if(!array_key_exists('iam_account_id', $data)) {
             $data['iam_account_id'] = UserHelper::currentAccount()->id;
         }
@@ -206,11 +206,11 @@ class AbstractKbArticlesService
                 $data['iam_user_id']
             );
         }
-                    
+
         if(!array_key_exists('iam_user_id', $data)) {
             $data['iam_user_id']    = UserHelper::me()->id;
         }
-            
+
         try {
             $model = KbArticles::create($data);
         } catch(\Exception $e) {
@@ -274,7 +274,7 @@ class AbstractKbArticlesService
                 $data['iam_user_id']
             );
         }
-    
+
         try {
             $isUpdated = $model->update($data);
             $model = $model->fresh();

--- a/src/Services/AbstractServices/AbstractSlaPoliciesService.php
+++ b/src/Services/AbstractServices/AbstractSlaPoliciesService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractSlaPoliciesService
 {
-    public static function get(SlaPoliciesQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?SlaPoliciesQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 
@@ -190,7 +190,7 @@ class AbstractSlaPoliciesService
                 $data['iam_account_id']
             );
         }
-            
+
         if(!array_key_exists('iam_account_id', $data)) {
             $data['iam_account_id'] = UserHelper::currentAccount()->id;
         }
@@ -200,11 +200,11 @@ class AbstractSlaPoliciesService
                 $data['iam_user_id']
             );
         }
-                    
+
         if(!array_key_exists('iam_user_id', $data)) {
             $data['iam_user_id']    = UserHelper::me()->id;
         }
-            
+
         try {
             $model = SlaPolicies::create($data);
         } catch(\Exception $e) {
@@ -262,7 +262,7 @@ class AbstractSlaPoliciesService
                 $data['iam_user_id']
             );
         }
-    
+
         try {
             $isUpdated = $model->update($data);
             $model = $model->fresh();

--- a/src/Services/AbstractServices/AbstractTestsService.php
+++ b/src/Services/AbstractServices/AbstractTestsService.php
@@ -23,7 +23,7 @@ use NextDeveloper\Support\Database\Models\Tests;
  */
 class AbstractTestsService
 {
-    public static function get(TestsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?TestsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 

--- a/src/Services/AbstractServices/AbstractTicketAuditsService.php
+++ b/src/Services/AbstractServices/AbstractTicketAuditsService.php
@@ -24,7 +24,7 @@ use NextDeveloper\Support\Database\Models\TicketAudits;
  */
 class AbstractTicketAuditsService
 {
-    public static function get(TicketAuditsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?TicketAuditsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 

--- a/src/Services/AbstractServices/AbstractTicketCommentsPerspectiveService.php
+++ b/src/Services/AbstractServices/AbstractTicketCommentsPerspectiveService.php
@@ -24,7 +24,7 @@ use NextDeveloper\Support\Database\Models\TicketCommentsPerspective;
  */
 class AbstractTicketCommentsPerspectiveService
 {
-    public static function get(TicketCommentsPerspectiveQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?TicketCommentsPerspectiveQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 

--- a/src/Services/AbstractServices/AbstractTicketCommentsService.php
+++ b/src/Services/AbstractServices/AbstractTicketCommentsService.php
@@ -23,7 +23,7 @@ use NextDeveloper\Support\Database\Models\TicketComments;
  */
 class AbstractTicketCommentsService
 {
-    public static function get(TicketCommentsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?TicketCommentsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 

--- a/src/Services/AbstractServices/AbstractTicketsService.php
+++ b/src/Services/AbstractServices/AbstractTicketsService.php
@@ -23,7 +23,7 @@ use NextDeveloper\Support\Database\Models\Tickets;
  */
 class AbstractTicketsService
 {
-    public static function get(TicketsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?TicketsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 

--- a/src/Services/TicketsService.php
+++ b/src/Services/TicketsService.php
@@ -53,7 +53,15 @@ class TicketsService extends AbstractTicketsService
 
         $data = self::normalizeCategory($data);
 
-        return parent::update($id, $data);
+        $ticket = parent::update($id, $data);
+
+        // A tag can be added after creation too (e.g. an agent re-tags an existing
+        // ticket as a bug report) - the job self-guards on tag presence and on
+        // already having filed, so it's safe to dispatch unconditionally here as
+        // well, mirroring create() below.
+        \App\Jobs\Support\CreateGithubIssueForCustomerBugReportJob::dispatch($ticket);
+
+        return $ticket;
     }
 
     public static function create(array $data)


### PR DESCRIPTION
Applies Rector's ExplicitNullableParamTypeRector across the package: `Type $x = null` -> `?Type $x = null`. Fixes the PHP 8.4 implicit-nullable-parameter deprecation notice.